### PR TITLE
fix(nextjs): Cannot set property 'reactRoot' of undefined on next 12.1

### DIFF
--- a/apps/editor/next.config.js
+++ b/apps/editor/next.config.js
@@ -2,4 +2,7 @@ const withTM = require("next-transpile-modules")(["@rimuru/ui"]);
 
 module.exports = withTM({
   reactStrictMode: true,
+    experimental: {
+    reactRoot: true
+  }
 });

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -13,10 +13,10 @@
     "@stitches/react": "^1.2.8",
     "canvas": "^2.9.1",
     "konva": "^8.3.8",
-    "next": "12.1.0",
+    "next": "^12.1.0",
     "node-fetch": "^2.6.7",
-    "react": "18.1.0",
-    "react-dom": "18.1.0",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0",
     "react-konva": "^18.1.0"
   },
   "devDependencies": {

--- a/apps/editor/pages/index.tsx
+++ b/apps/editor/pages/index.tsx
@@ -22,6 +22,7 @@ export default function Web() {
 
   return (
     <Flex css={{ flexDirection: "column" }}>
+      <Button>Test Ui Package Button</Button>
       <Flex css={{ flexDirection: "column" }}>
         <MainMenu>
           <a href="/#">Projeto</a>


### PR DESCRIPTION
When using React 18 and Nextjs >12 must set the experimental for reactRoot inside the nextjs config file.